### PR TITLE
Change default format from ply to obj

### DIFF
--- a/man/banc_read_neuron_meshes.Rd
+++ b/man/banc_read_neuron_meshes.Rd
@@ -6,7 +6,7 @@
 \alias{banc_read_nuclei_mesh}
 \title{Read one or more BANC neuron and nuclei meshes}
 \usage{
-banc_read_neuron_meshes(ids, savedir = NULL, format = c("ply", "obj"), ...)
+banc_read_neuron_meshes(ids, savedir = NULL, format = c("obj","ply"), ...)
 
 banc_read_mitochondria_mesh(
   ids,


### PR DESCRIPTION
Related to #17 
Reading .ply files depends on the Rvcg package, which is not installed by default with bancr; if missing, functions may return an empty neuronlist without throwing an error. In contrast, reading .obj files does not require Rvcg, making it a more robust default workflow.